### PR TITLE
Fixed ncbi_taxonomy bug

### DIFF
--- a/genetic_collections/ncbi_functions.py
+++ b/genetic_collections/ncbi_functions.py
@@ -1,7 +1,5 @@
 import requests
-# import pandas as pd
 from lxml import objectify
-# import json
 from collections import namedtuple
 from operator import itemgetter
 import re
@@ -239,11 +237,13 @@ def ncbi_taxonomy(gb_fetch_results, batch_size=250, api_key = None):
     :rtype: list of dictionaries
     """
 
-    try:
-        taxid_list = list(set([x['taxid'] for x in gb_fetch_results]))
-    except KeyError:
-        print('Must provide gb_fetch_from_id_list results.')
-        return
+    taxid_list = set()
+    for fetchresult in gb_fetch_results:
+        try:
+            taxid_list.add(fetchresult['taxid'])
+        except KeyError:
+            continue
+    taxid_list = list(taxid_list)
     result_count = len(taxid_list)
     parsed_results = []
     i = 0

--- a/genetic_collections/ncbi_functions.py
+++ b/genetic_collections/ncbi_functions.py
@@ -241,10 +241,13 @@ def ncbi_taxonomy(gb_fetch_results, batch_size=250, api_key = None):
     for fetchresult in gb_fetch_results:
         try:
             taxid_list.add(fetchresult['taxid'])
-        except KeyError:
+        except (KeyError, TypeError) as e:
             continue
     taxid_list = list(taxid_list)
     result_count = len(taxid_list)
+    if result_count == 0:
+        print('Must supply gb_fetch_from_id_list() results.')
+        return
     parsed_results = []
     i = 0
     while i < result_count:


### PR DESCRIPTION
I found a bug with the ncbi_taxonomy() function that caused it to fail if one of the fetched GenBank records did not have an associated `taxid` (due to record parsing problems). The function will now skip over that problem record instead.