### PR TITLE
Add option to specify idtype as kwarg

### DIFF
--- a/genetic_collections/ncbi_functions.py
+++ b/genetic_collections/ncbi_functions.py
@@ -90,6 +90,14 @@ def gb_search(format='variable', api_key = None, **kwargs):
                      'retmax': 10000000}
     if api_key:
         search_params['api_key'] = api_key
+    
+    # Return GI number (default) or accession.version (idtype='acc')
+    if ('idtype' in kwargs):
+        if kwargs['idtype'] == 'acc':
+            search_params['idtype'] = 'acc'
+        else:
+            print('Invalid idtype specified, returning default GI number.')
+
     r = requests.get(search_url, params=search_params)
     search_results = objectify.fromstring(r.content)
     id_list = [id_entry.text for id_entry in search_results.IdList.iterchildren()]


### PR DESCRIPTION
ESearch added an option to specify whether the user would like to return a list of GI numbers (default), or a list of Accession.Version numbers (with parameter idtype=acc). According to the documentation, either type of number is accepted by EFetch without having to specify any extra parameters. See https://www.ncbi.nlm.nih.gov/books/NBK25499/#_chapter4_ESearch_ for further details.

I added the option to return Accession.Version IDs from `gb_search` via a kwarg `idtype='acc'`. Let me know if you see any problems with the code!